### PR TITLE
Set new styles for .cartCounter selector

### DIFF
--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -47,17 +47,18 @@
       }
 
       .cartCounter {
-        width: 28px;
+        width: fit-content;
+        border: 1px solid #d58e32;
+        padding: 8.5px;
         height: 27px;
         border-radius: 14px;
-        background-color: $header-bg;
+        background-color: #363636;
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 14px;
-        color: rgb(224, 227, 237);
+        color: #ffffff;
         position: absolute;
-        top: 50%;
         right: 0;
         transform: translate(50%, -50%);
       }

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -48,16 +48,16 @@
 
       .cartCounter {
         width: fit-content;
-        border: 1px solid #d58e32;
+        border: 1px solid $primary;
         padding: 8.5px;
         height: 27px;
         border-radius: 14px;
-        background-color: #363636;
+        background-color: $footer-bg;
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 14px;
-        color: #ffffff;
+        color: $light-text-color;
         position: absolute;
         right: 0;
         transform: translate(50%, -50%);

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -9,5 +9,6 @@ $footer-bg: #363636;
 $primary: #d58e32;
 
 $text-color: #2a2a2a;
+$light-text-color: #ffffff;
 
 $form-border-color: #292929;


### PR DESCRIPTION
I set alternative styles for the .cartCounter selector. 
Adding `width: fit-content` would be enough. But I decided to add an additional **orange border color** and **8.5px padding** - with single numbers, border looks more rounded. 
I changed the **color** of the number - in the future it will improve the possibility of making global changes.

Link to Jira task: 
<a href="https://projects.kodilla.com/browse/WDP230402-2" alt="jiraLink">https://projects.kodilla.com/browse/WDP230402-2</a>

Two examples below:
<img width="86" alt="Zrzut ekranu 2023-04-13 o 08 22 28" src="https://user-images.githubusercontent.com/117603283/231672776-272cbfc0-233c-48d3-bb1d-bcfb7957c440.png">

<img width="98" alt="Zrzut ekranu 2023-04-13 o 08 22 52" src="https://user-images.githubusercontent.com/117603283/231672794-4ac740b2-5949-4ffa-a9ed-f8983bc5cebe.png">

