### PR TITLE
Bug/wdp230402 4/display product box buttons

### DIFF
--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -81,4 +81,9 @@
     .buttons {
       visibility: visible;
     }
+
+    .price > div {
+      background-color: $primary;
+    }
+  }
 }

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -31,6 +31,7 @@
     .buttons {
       display: flex;
       justify-content: space-between;
+      visibility: hidden;
     }
   }
 
@@ -75,4 +76,9 @@
     justify-content: space-between;
     align-items: center;
   }
+
+  &:hover {
+    .buttons {
+      visibility: visible;
+    }
 }


### PR DESCRIPTION
I've added a new declaration `visibillity: hidden` for *.buttons* selector. After hovering, ProductBox component:
- *visibility* property changes value on *visible*,
- Price button changes its background color to orange.
What is important visible buttons don't change height of ProductBox component.

Link to Jira task:
https://projects.kodilla.com/browse/WDP230402-4

ProductBox without hover effect. 
<img width="264" alt="Zrzut ekranu 2023-04-13 o 19 21 06" src="https://user-images.githubusercontent.com/117603283/231836476-e3f138e5-2a5c-49b0-9fe6-cb2ec80dcc3d.png">

ProductBox with hover effect. 
<img width="264" alt="Zrzut ekranu 2023-04-13 o 19 21 16" src="https://user-images.githubusercontent.com/117603283/231836807-a2c41b55-a420-4e20-b0c8-3e5ee47e9fce.png">

