### PR TITLE
Feature/wdp230402 16/rwd benefit cards

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -76,3 +76,9 @@
     }
   }
 }
+
+@media (max-width: 767px) {
+  h5 {
+    word-spacing: 150px;
+  }
+}

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -15,25 +15,25 @@ const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
       <div className='row'>
-        <div className='col'>
+        <div className='col-6 col-lg'>
           <FeatureBox icon={faTruck} active>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg'>
           <FeatureBox icon={faHeadphones}>
             <h5>24/7 customer</h5>
             <p>support</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg'>
           <FeatureBox icon={faReplyAll}>
             <h5>Money back</h5>
             <p>guarantee</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg'>
           <FeatureBox icon={faBullhorn}>
             <h5>Member discount</h5>
             <p>First order</p>

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -1,5 +1,5 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  padding: 5rem 0,
+  padding: 5rem 0;
 }

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -1,5 +1,5 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  padding: 5rem 0;
+  padding: 5rem 0,
 }


### PR DESCRIPTION
dodałam col-6 dla rozdzielczości tablet i mobile oraz ustawiłam word-spacing, żeby w danych rozdzielczościach wyrazy były w dwóch liniach
jira: https://projects.kodilla.com/browse/WDP230402-16